### PR TITLE
added overrides for system-specific views from badgekit_webhooks

### DIFF
--- a/hook_project/templates/badgekit_webhooks/claim_email.txt
+++ b/hook_project/templates/badgekit_webhooks/claim_email.txt
@@ -1,0 +1,9 @@
+Hi!
+
+Congratulations!  You have been awarded a digital badge in recognition for your
+contributions to Open edX!  You can go to the URL below to claim your badge,
+and show it off to the world.
+
+{{ claim_url }}
+
+Thanks for your work!

--- a/hook_project/templates/badgekit_webhooks/claim_page.html
+++ b/hook_project/templates/badgekit_webhooks/claim_page.html
@@ -1,0 +1,53 @@
+{% extends "badgekit_webhooks/app_base.html" %}
+
+{% block extra_script %}
+<script src="https://backpack.openbadges.org/issuer.js"></script>
+{% endblock %}
+
+{% block body %}
+  <div class="alert alert-success">
+    <strong>Well done!</strong> You earned a badge. Now you can add it to your backpack.
+  </div>
+
+  <div class="jumbotron">
+    <h1>You've earned a badge.</h1>
+
+    <p class="lead">Claim your rightful place among the noble, the steadfast, and the brave: the fellowship of edX code contributors.</p>
+
+    <p class="badge-image">
+      <img src="{{ badge_image }}">
+    </p>
+
+    <p><a class="btn btn-lg btn-success" href="javascript:issueBadge();" role="button">Send to backpack</a></p>
+  </div>
+
+  <div class="row marketing">
+    <div class="col-lg-6">
+      <h4>About edX badges</h4>
+      <p><a href="">Read all about</a> edX's commitment to open badges.</p>
+    </div>
+
+    <div class="col-lg-6">
+      <h4>Criteria for this badge</h4>
+      <p>Others can do one of <a href="#">these awesome tasks</a> to join you in earning this badge.</p>
+    </div>
+
+  </div>
+
+  <div class="alert alert-info">
+    If this is a real claim page, the assertion for the badge instance lives
+    <a id="assertionUrl" href="{{ assertionUrl }}">here.</a>
+  </div>
+
+
+  <script>
+    function issueBadge() {
+      var assertionUrl = $('a#assertionUrl').attr('href');
+      OpenBadges.issue([assertionUrl], function(errors, successes) {
+          if (errors) {
+            console.log(errors);
+          }
+      });
+    }
+  </script>
+{% endblock %}

--- a/hook_project/templates/homepage.html
+++ b/hook_project/templates/homepage.html
@@ -42,5 +42,5 @@
 {% block column-3 %}
     <h2>Contributor Badges</h2>
     <p>Here are the badges available for contributors to OPEN edX.</p>
-    <p><a class="btn btn-default" href="#">See badges &raquo;</a></p>
+    <p><a class="btn btn-default" href="/bk/badges">See badges &raquo;</a></p>
 {% endblock %}


### PR DESCRIPTION
The templates folder added works to override templates from apps/badgekit_webhooks.
